### PR TITLE
 Use source artifacts that come with update report

### DIFF
--- a/src/main/scala/com/typesafe/sbteclipse/core/EclipseOpts.scala
+++ b/src/main/scala/com/typesafe/sbteclipse/core/EclipseOpts.scala
@@ -28,6 +28,10 @@ private object EclipseOpts {
 
   val WithJavadoc = "with-javadoc"
 
+  val WithUserSetSource = "with-user-set-source"
+
+  val WithUserSetJavadoc = "with-user-set-javadoc"
+
   val UseProjectId = "use-project-id"
 
   val WithBundledScalaContainers = "with-bundled-scala-containers"

--- a/src/main/scala/com/typesafe/sbteclipse/core/EclipsePlugin.scala
+++ b/src/main/scala/com/typesafe/sbteclipse/core/EclipsePlugin.scala
@@ -51,6 +51,8 @@ object EclipsePlugin {
       skipParents := true,
       withSource := false,
       withJavadoc := false,
+      withUserSetSource := false,
+      withUserSetJavadoc := false,
       projectFlavor := EclipseProjectFlavor.ScalaIDE,
       withBundledScalaContainers := projectFlavor.value.id == EclipseProjectFlavor.ScalaIDE.id,
       classpathTransformerFactories := defaultClasspathTransformerFactories(withBundledScalaContainers.value),
@@ -135,6 +137,16 @@ object EclipsePlugin {
     val withJavadoc: SettingKey[Boolean] = SettingKey(
       prefix(WithJavadoc),
       "Download and link javadoc for library dependencies?"
+    )
+
+    val withUserSetSource: SettingKey[Boolean] = SettingKey(
+      prefix(WithUserSetSource),
+      "Link sources for library dependencies annotated by 'withSource'?"
+    )
+
+    val withUserSetJavadoc: SettingKey[Boolean] = SettingKey(
+      prefix(WithUserSetJavadoc),
+      "Link javadocs for library dependencies annotated by 'withJavadoc'?"
     )
 
     val withBundledScalaContainers: SettingKey[Boolean] = SettingKey(

--- a/src/sbt-test/sbteclipse/07-dependency-classifiers/build.sbt
+++ b/src/sbt-test/sbteclipse/07-dependency-classifiers/build.sbt
@@ -1,0 +1,32 @@
+import scala.xml.XML
+
+EclipseKeys.withSource := false
+EclipseKeys.withJavadoc := false
+
+EclipseKeys.withUserSetSource := true
+EclipseKeys.withUserSetJavadoc := true
+
+organization := "com.typesafe.sbteclipse"
+
+name := "sbteclipse-test"
+
+version := "1.2.3"
+
+libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.0.1"
+
+libraryDependencies += "biz.aQute" % "bndlib" % "1.50.0" withSources() 
+
+libraryDependencies += "org.specs2" %% "specs2" % "2.1.1" % "test" withSources()
+
+TaskKey[Unit]("verify-classpath-xml") <<= baseDirectory map { dir =>
+  val home = System.getProperty("user.home")
+  val classpath = XML.loadFile(dir / ".classpath")
+  // lib entries with sources
+  def verifySrcClasspathEntry(libPath: String, srcPath: String) =
+    if (!(classpath.child contains <classpathentry kind="lib" path={ libPath } sourcepath={ srcPath } />)) 
+      error("""Expected .classpath of project to contain <classpathentry kind="lib" path="%s" sourcepath="%s" />: %s""".format(libPath, srcPath, classpath))
+    
+  
+  verifySrcClasspathEntry(home + "/.ivy2/cache/biz.aQute/bndlib/jars/bndlib-1.50.0.jar", home + "/.ivy2/cache/biz.aQute/bndlib/srcs/bndlib-1.50.0-sources.jar")
+  verifySrcClasspathEntry(home + "/.ivy2/cache/org.specs2/specs2_2.10/jars/specs2_2.10-2.1.1.jar", home + "/.ivy2/cache/org.specs2/specs2_2.10/srcs/specs2_2.10-2.1.1-sources.jar")
+}

--- a/src/sbt-test/sbteclipse/07-dependency-classifiers/project/plugins.sbt
+++ b/src/sbt-test/sbteclipse/07-dependency-classifiers/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % pluginVersion)
+}

--- a/src/sbt-test/sbteclipse/07-dependency-classifiers/src/main/scala/Main.scala
+++ b/src/sbt-test/sbteclipse/07-dependency-classifiers/src/main/scala/Main.scala
@@ -1,0 +1,1 @@
+object Main

--- a/src/sbt-test/sbteclipse/07-dependency-classifiers/test
+++ b/src/sbt-test/sbteclipse/07-dependency-classifiers/test
@@ -1,0 +1,4 @@
+> clean
+> compile
+> eclipse skip-parents=false
+> verify-classpath-xml


### PR DESCRIPTION
This pull request addresses issue #105 
When user annotates artifact by withSources() classifier the sources for that artifact will be downloaded during 'update'. So nothing prevents sbteclipse to actually link those already downloaded sources to eclipse libraries.
I have introduced two params - userSetSource and userSetJavadoc that will do exactly that. To minimize any error I have defaulted them to 'false', although I think it is safe enough to make them enabled by default.
I know that use of withSources() classifier is discouraged, although I don't know exact reason. But this use case is somehow useful when user includes large library, like spark, and doesn't want to download all sources transitively. 
Personally I'd love to see this feature in sbteclipse.
